### PR TITLE
Add left-right graph layout option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,13 @@
 Changes
 =======
 
+
+0.2.1 (*2019-08-06*)
+====================
+
+- Support drawing tasks in left-to-right layout using `--horizontal` or `-h` option
+
+
 0.2.0 (*2019-07-27*)
 ====================
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ $ dot -Tpng tasks.dot -o tasks.png
 $ doit graph --reverse
 ```
 
+- To draw tasks from left-to-right instead of the default top-to-bottom, use option `--horizontal` or `-h`
+
+```
+$ doit graph --horizontal
+```
+
 ### legend
 
 ![Legend](/legend.png)

--- a/doit_graph.py
+++ b/doit_graph.py
@@ -33,6 +33,15 @@ opt_reverse = {
     'help': 'draw edge in execution order, i.e. the reverse of dependency direction'
 }
 
+opt_horizontal = {
+    'name': 'horizontal',
+    'short': 'h',
+    'long': 'horizontal',
+    'type': bool,
+    'default': False,
+    'help': 'draw graph in left-right mode, i.e. add rankdir=LR to digraph output'
+}
+
 opt_outfile = {
     'name': 'outfile',
     'short': 'o',
@@ -62,7 +71,7 @@ Website/docs: https://github.com/pydoit/doit-graph
     """
     doc_usage = "[TASK ...]"
 
-    cmd_options = (opt_subtasks, opt_outfile, opt_reverse)
+    cmd_options = (opt_subtasks, opt_outfile, opt_reverse, opt_horizontal)
 
 
     def node(self, task_name):
@@ -84,7 +93,7 @@ Website/docs: https://github.com/pydoit/doit-graph
             self.graph.add_edge(source, sink, arrowhead=arrowhead)
 
 
-    def _execute(self, subtasks, reverse, outfile, pos_args=None):
+    def _execute(self, subtasks, reverse, horizontal, outfile, pos_args=None):
         # init
         control = TaskControl(self.task_list)
         self.tasks = control.tasks
@@ -95,6 +104,9 @@ Website/docs: https://github.com/pydoit/doit-graph
         self.graph = pygraphviz.AGraph(strict=False, directed=True)
         self.graph.node_attr['color'] = 'lightblue2'
         self.graph.node_attr['style'] = 'filled'
+
+        if (horizontal):
+            self.graph.graph_attr.update(rankdir='LR')
 
         # populate graph
         processed = set() # str - task name


### PR DESCRIPTION
Graphviz allows for a horizontal, or left-to-right drawing method, with the [rankdir=LR](https://www.graphviz.org/doc/info/attrs.html#d:rankdir) command. This patch adds that option to the .dot file output, with the inclusion of the -h or --horizontal command line argument. Example:

`$ doit graph --horizontal`

Tested on Python 3.7 / Ubuntu 18.04.